### PR TITLE
Add Silk.NET to binding list

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ The bindings are based on the WebGPU-native header found at `ffi/webgpu-headers/
 
 - [gfx-rs/wgpu-rs](https://github.com/gfx-rs/wgpu/tree/master/wgpu) - idiomatic Rust wrapper with [a few more examples](https://github.com/gfx-rs/wgpu/tree/master/wgpu/examples) to get a feel of the API
 - [pygfx/wgpu-py](https://github.com/pygfx/wgpu-py) - Python wrapper
-- [trivaxy/wgpu.NET](https://github.com/trivaxy/WGPU.NET) - .Net wrapper
+- [trivaxy/wgpu.NET](https://github.com/trivaxy/WGPU.NET) - .NET wrapper
+- [dotnet/Silk.NET](https://github.com/dotnet/Silk.NET) - Raw .NET bindings
 - [wgpu.cr](https://github.com/chances/wgpu-crystal) - Crystal wrapper
 - [bindc-wgpu](https://github.com/gecko0307/bindbc-wgpu) - D wrapper ([package](https://code.dlang.org/packages/bindbc-wgpu))
 - [porky11/wgpu](https://gitlab.com/scopes-libraries/wgpu) - experimental [Scopes](http://scopes.rocks) wrapper


### PR DESCRIPTION
Silk.NET now has raw WebGPU bindings for C# (as opposed to wgpu.NET, which acts a lot more as a wrapper)